### PR TITLE
 Additional funcionality: enable second caption and placement

### DIFF
--- a/latexTable.m
+++ b/latexTable.m
@@ -140,7 +140,7 @@ if ~isfield(input,'makeCompleteLatexDocument'),input.makeCompleteLatexDocument =
 
 % Enable and specify second caption, with supressed numbering
 if ~isfield(input,'EnableSecondCaption'),input.EnableSecondCaption = 0;end
-if ~isfield(input,'SecondCaption'), input.secondCaption = 'MySecondTableCaption';end
+if ~isfield(input,'secondCaption'), input.secondCaption = 'MySecondTableCaption';end
 
 % Specify placement of the caption (IEEE and Brazilian Standard (ABNT) require caption to be on top) 
 if ~isfield(input,'CaptionPlacement'),input.CaptionPlacement='bottom';end

--- a/latexTable.m
+++ b/latexTable.m
@@ -137,6 +137,15 @@ end
 if ~isfield(input,'tableCaption'),input.tableCaption = 'MyTableCaption';end
 if ~isfield(input,'tableLabel'),input.tableLabel = 'MyTableLabel';end
 if ~isfield(input,'makeCompleteLatexDocument'),input.makeCompleteLatexDocument = 0;end
+
+% Enable and specify second caption, with supressed numbering
+if ~isfield(input,'EnableSecondCaption'),input.EnableSecondCaption = 0;end
+if ~isfield(input,'SecondCaption'), input.secondCaption = 'MySecondTableCaption';end
+
+% Specify placement of the caption (IEEE and Brazilian Standard (ABNT) require caption to be on top) 
+if ~isfield(input,'CaptionPlacement'),input.CaptionPlacement='bottom';end
+
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 % process table datatype
@@ -204,7 +213,14 @@ if input.tableBorders
 else
     header = ['\begin{tabular}','{',repmat(input.tableColumnAlignment,1,size(C,2)),'}'];
 end
-latex = {['\begin{table}',input.tablePlacement];'\centering';header};
+
+if strcmp(input.CaptionPlacement,'top')
+    latex = {['\begin{table}',input.tablePlacement];'\centering';['\caption{',input.tableCaption,'}'];header};
+elseif input.EnableSecondCaption
+    latex = {['\begin{table}',input.tablePlacement];'\centering';['\caption*{',input.secondCaption,'}'];header};
+else
+    latex = {['\begin{table}',input.tablePlacement];'\centering';header};
+end
 
 % generate table
 if input.booktabs
@@ -243,8 +259,15 @@ end
 
 
 % make footer lines for table:
-tableFooter = {'\end{tabular}';['\caption{',input.tableCaption,'}']; ...
-    ['\label{table:',input.tableLabel,'}'];'\end{table}'};
+if strcmp(input.CaptionPlacement,'bottom')
+    tableFooter = {'\end{tabular}';['\caption{',input.tableCaption,'}']; ...
+        ['\label{table:',input.tableLabel,'}'];'\end{table}'};
+elseif input.EnableSecondCaption
+    tableFooter = {'\end{tabular}';['\caption*{',input.secondCaption,'}']; ...
+        ['\label{table:',input.tableLabel,'}'];'\end{table}'};
+else
+    tableFooter = {'\end{tabular}';['\label{table:',input.tableLabel,'}'];'\end{table}'};
+end
 if input.tableBorders
     latex = [latex;{hLine};tableFooter];
 else


### PR DESCRIPTION
I use latexTable to generate some tables for my PhD thesis, which should be written according to a common standard in Brasil, known as _ABNT_. According to such standard, the main table caption should be placed on top of the caption. In addition, there should also be a second caption informing the source from which the table data was drawn. 

For that, I added the parameters:
```matlab
% Enables the second caption
input.EnableSecondCaption = 1;

% The text of the second caption
input.secondCaption = "Source: where the data came from"

% Places the main caption on top of the table
% (if empty, the placement is set to 'bottom')
input.CaptionPlacement = 'top'
```
Example
```matlab
input.data = [1.12345 2.12345 3.12345; ...
              4.12345 5.12345 6.12345; ...
              7.12345 NaN 9.12345; ...
              10.12345 11.12345 12.12345];

input.CaptionPlacement = 'top';
input.EnableSecondCaption = 1;
input.secondCaption = 'Source: random data';

latex = latexTable(input);
```

Output:
```latex
\begin{table}                 
\centering                    
\caption{MyTableCaption}      
\begin{tabular}{|c|c|c|}      
\hline                        
1.1235 & 2.1235 & 3.1235 \\   
\hline                        
4.1235 & 5.1235 & 6.1235 \\   
\hline                        
7.1235 & - & 9.1235 \\        
\hline                        
10.1235 & 11.1235 & 12.1235 \\
\hline                        
\end{tabular}                 
\caption*{Source: random data}
\label{table:MyTableLabel}    
\end{table}      
```

